### PR TITLE
Handle case where no release data is available. Fixes #3

### DIFF
--- a/src/rels.js
+++ b/src/rels.js
@@ -221,30 +221,31 @@ class Rels {
     });
   }
 
-  _getAll(repo) {
-    return this._get(this._path.releases(repo));
-  }
+  async _getReleaseData(repo) {
+    const total = await this._get(this._path.releases(repo));
 
-  _getLatest(repo) {
-    return this._get(this._path.latest(repo));
+    if (Array.isArray(total) && total.length === 0) {
+      throw new Error(`No available release data for the ${repo} repository`);
+    }
+
+    const latest = await this._get(this._path.latest(repo));
+
+    return [total, latest];
   }
 
   async init(repo, n) {
-    let [data, latest] = [];
+    let [total, latest] = [];
 
     try {
-      [data, latest] = await Promise.all([
-        this._getAll(repo),
-        this._getLatest(repo)
-      ]);
+      [total, latest] = await this._getReleaseData(repo);
     } catch (error) {
       return fatal(error);
     }
 
     this._latestRelease = Object.assign({}, latest);
-    [data, n] = [this._formatData(data), this._format.listN(n)];
+    [total, n] = [this._formatData(total), this._format.listN(n)];
 
-    this._display(repo, data, n);
+    this._display(repo, total, n);
   }
 }
 


### PR DESCRIPTION
## Description

The PR adds the ability to handle the cases where no release data is available for the given repository. 
For those special cases, the following error message will be printed to the console:

```
$ rels --repo $username/$repository
✖  Error: No available release data for the $username/$repository repository
```